### PR TITLE
Mark some tests as heavy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,4 +157,3 @@ tmp_plots/
 
 # models saved locally
 models/
-

--- a/lizrd/core/test_misc.py
+++ b/lizrd/core/test_misc.py
@@ -4,7 +4,7 @@ import torch
 from lizrd.core import llm, misc
 from lizrd.core.misc import Chungus, Checkpoint
 from lizrd.datasets.wikibookdata import get_processed_dataset
-from lizrd.support.test_utils import GeneralTestCase
+from lizrd.support.test_utils import GeneralTestCase, heavy_test
 from lizrd.train.train_utils import get_model
 from research.conditional.utils.model_utils import (
     calculate_bert_loss,
@@ -129,6 +129,7 @@ class TestChungus(GeneralTestCase):
 
 
 class TestChungizedCalculateLoss(GeneralTestCase):
+    @heavy_test
     def test_outputs_and_grads(self):
         torch.manual_seed(0)
 

--- a/lizrd/datasets/test_wikibookdata.py
+++ b/lizrd/datasets/test_wikibookdata.py
@@ -1,7 +1,7 @@
 from lizrd.datasets import wikibookdata
 import lizrd.datasets.processed_batch
 from lizrd.datasets.wikibookdata import get_processed_dataset
-from lizrd.support.test_utils import GeneralTestCase, skip_test
+from lizrd.support.test_utils import GeneralTestCase, skip_test, heavy_test
 import pickle
 
 
@@ -22,6 +22,7 @@ class TestWikibookdata(GeneralTestCase):
         self.assertShape(processed_batch.special_token_mask, (batch_size, max_len))
         self.assertShape(processed_batch.special_token_mask, (batch_size, max_len))
 
+    @heavy_test
     def test_consistency(self):
         ds = get_processed_dataset(32, 128, 0.15, "cpu", 2, 1)
         batch = ds.get_batch()
@@ -32,6 +33,7 @@ class TestWikibookdata(GeneralTestCase):
         self.assertTensorEqual(batch.tokens, saved_batch.tokens)
         self.assertTensorEqual(batch.mask_mask, saved_batch.mask_mask)
 
+    @heavy_test
     def test_integration(self):
         bs = 32
         max_len = 128


### PR DESCRIPTION
# Description
Mark tests using datasets as heavy to make precommit checks faster.

# Checklist
Answer each question with "yes", and provide an explanation if the answer isn't what is expected.

1. Is this PR focused on a single feature without the possibility of being divided into smaller PRs?
   - Answer: yes
2. Are all variables set with logical defaults that are backward compatible?
   - Answer:yes
3. Can you provide a link to a Neptune experiment verifying the functionality of this PR?
   - Answer:n/a
4. Have you successfully executed the linter and tests?
   - Answer:yes
5. Are all functions concise and don't require splitting?
   - Answer:yes
6. Is there documentation for arguments and complex logic?
   - Answer:yes
7. Are there no temporary solutions in the code? Should a task be added to Trello to refine the code?
   - Answer:the heavy tests should be run server-side. Maybe task for adding those test should be added ?
8. Are all functions placed in appropriate files?
   - Answer:yes
9. Is the PR name meaningful and descriptive?
   - Answer:yes
10. Is PR description provided, or unnecessary?
    - Answer:yes
  
Other questions:

11. Have you not made changes to the requirements or anything related to the Singularity image? If you have, did you generate and upload a new image to the clusters?
    - Answer:no such changes
12. Is the change significant enough to notify all individuals working with this repository?
    - Answer:no
13. Is there a need for a second reviewer?
    - Answer:no
