### PR TITLE
Legacy loss for bert

### DIFF
--- a/research/conditional/utils/argparse.py
+++ b/research/conditional/utils/argparse.py
@@ -21,7 +21,7 @@ def introduce_parser_arguments(parser):
     parser.add_argument("--torch_seed", type=int, default=42)
     parser.add_argument("--deterministic_experiment", action="store_true")
     parser.add_argument("--tags", nargs="*", type=str, default=None)
-    parser.add_argument("--project_name", type=str, default="pmtest/llm-random")
+    parser.add_argument("--project_name", type=str, default="pmtest/llm-efficiency")
     parser.add_argument(
         "--model_type", type=str, choices=["gpt", "bert"], default="bert"
     )

--- a/research/conditional/utils/conditional_trainer.py
+++ b/research/conditional/utils/conditional_trainer.py
@@ -64,6 +64,10 @@ class ConditionalTrainer:
         self.loss_accumulators["loss"] = SN(
             acc=0.0, interval=self.logging_interval_loss
         )
+        if self.model_type == "bert":
+            self.loss_accumulators["legacy_bert_bugged_loss"] = SN(
+                acc=0.0, interval=self.logging_interval_loss
+            )
         self.correct_tokens_accumulator = 0.0
         self.total_tokens_accumulator = 0.0
         self._calculate_loss = make_loss_function(
@@ -226,7 +230,14 @@ class ConditionalTrainer:
         if self.lr_scheduler is not None:
             self.lr_scheduler.step()
         if self.logger is not None:
-            self._log_train_stats(loss, step)
+            if self.model_type == "bert":
+                mask_percent = self.mask_percent
+                numel = processed_batch.tokens.numel()
+                real_mask_percent = aux_info["total_masked_tokens"] / numel
+                aux_info["legacy_bert_bugged_loss_multiplier"] = (
+                    real_mask_percent / mask_percent
+                )
+            self._log_train_stats(loss, step, aux_info)
             self._log_accuracy(aux_info, step)
             self.layer_manager.log(step)
             self._log_heavy(step)
@@ -266,7 +277,7 @@ class ConditionalTrainer:
             "total_masked_tokens": total_masked_tokens_value,
         }
 
-    def _log_train_stats(self, loss_value, step):
+    def _log_train_stats(self, loss_value, step, aux_info):
         self.logger.report_scalar(title="step", value=step, iteration=step)
         if self.lr_scheduler is not None:
             self.logger.report_scalar(
@@ -275,7 +286,13 @@ class ConditionalTrainer:
         if self.train_dataloader.dataset_type == "c4":
             self._log_fraction_dataset_processed(step)
         for name, stats in self.loss_accumulators.items():
-            stats.acc += loss_value
+            if name == "legacy_bert_bugged_loss":
+                bert_legacy_loss = (
+                    loss_value * aux_info["legacy_bert_bugged_loss_multiplier"]
+                )
+                stats.acc += bert_legacy_loss
+            else:
+                stats.acc += loss_value
             if step % stats.interval == 0 and step > 0:
                 self.logger.report_scalar(
                     title=name,


### PR DESCRIPTION
# Description
add loss for BERT as calculated before the debug. To be reverted by Oct 1.

# Checklist
Answer each question with "yes", and provide an explanation if the answer isn't what is expected.

1. Is this PR focused on a single feature without the possibility of being divided into smaller PRs?
   - Answer: yes
2. Are all variables set with logical defaults that are backward compatible?
   - Answer: yes
3. Can you provide a link to a Neptune experiment verifying the functionality of this PR?
   - Answer: [link](https://app.neptune.ai/o/pmtest/org/llm-random/runs/details?viewId=standard-view&detailsTab=charts&shortId=LLMRANDOM-62&type=run&lbViewUnpacked=true&sortBy=%5B%22sys%2Fcreation_time%22%5D&sortFieldType=%5B%22datetime%22%5D&sortFieldAggregationMode=%5B%22auto%22%5D&sortDirection=%5B%22descending%22%5D&query=) is new and [these](https://app.neptune.ai/o/pmtest/org/llm-efficiency/runs/compare?viewId=9877451c-8578-48c7-84c2-addf7c82b2d3&detailsTab=charts&shortId=LLMEF-3231&dash=charts&type=run&lbViewUnpacked=true&sortBy=%5B%22sys%2Fcreation_time%22%5D&sortFieldType=%5B%22datetime%22%5D&sortFieldAggregationMode=%5B%22auto%22%5D&sortDirection=%5B%22descending%22%5D&suggestionsEnabled=false&query=((%60sys%2Fowner%60%3Astring%20%3D%20%22simontwice%22)%20OR%20(%60sys%2Fowner%60%3Astring%20%3D%20%22crewtool%22))%20AND%20(%60args%2Fff_mode%60%3Astring%20%3D%20%22vanilla%22)%20AND%20(last(%60step%60%3AfloatSeries)%20%3E%2060000)&compare=MwJhE4BoEYaA) are old baselines
4. Have you successfully executed the linter and tests?
   - Answer: yes
5. Are all functions concise and don't require splitting?
   - Answer: yes
6. Is there documentation for arguments and complex logic?
   - Answer: yes
7. Are there no temporary solutions in the code? Should a task be added to Trello to refine the code?
   - Answer: the solution is indeed temporary, https://trello.com/c/W8UqQtrY
8. Are all functions placed in appropriate files?
   - Answer: yes
9. Is the PR name meaningful and descriptive?
   - Answer: yes
10. Is PR description provided, or unnecessary?
    - Answer: yes
  
Other questions:

11. Have you not made changes to the requirements or anything related to the Singularity image? If you have, did you generate and upload a new image to the clusters?
    - Answer: no changes
12. Is the change significant enough to notify all individuals working with this repository?
    - Answer: yes
13. Is there a need for a second reviewer?
    - Answer: no
