### PR TITLE
Fix mixed precision

### DIFF
--- a/lizrd/datasets/wikibookdata.py
+++ b/lizrd/datasets/wikibookdata.py
@@ -47,7 +47,7 @@ def process_book_text(document_sentences, chunk_length: int = 450):
 
 
 class WikiBookDataset:
-    def __init__(self, rng=random.Random(), use_dummy_dataset=False):
+    def __init__(self, rng=random, use_dummy_dataset=False):
         self.examples_buffer = []
         self.dataset_wiki = load_dataset(
             "wikipedia", f"20220301.{'simple' if use_dummy_dataset else 'en'}"

--- a/lizrd/datasets/wikibookdata.py
+++ b/lizrd/datasets/wikibookdata.py
@@ -47,7 +47,7 @@ def process_book_text(document_sentences, chunk_length: int = 450):
 
 
 class WikiBookDataset:
-    def __init__(self, rng=random, use_dummy_dataset=False):
+    def __init__(self, rng=random.Random(), use_dummy_dataset=False):
         self.examples_buffer = []
         self.dataset_wiki = load_dataset(
             "wikipedia", f"20220301.{'simple' if use_dummy_dataset else 'en'}"


### PR DESCRIPTION
# Description
Fix mixed precision usage in both chungized and unchungized loss calculation. 
In unchungized version, loss calculation was outside the context manager.
In chungized version, _only_ the unembedding and loss calculation were inside the context manager.

# Checklist
Answer each question with "yes", and provide an explanation if the answer isn't what is expected.

1. Is this PR focused on a single feature without the possibility of being divided into smaller PRs?
   - Answer: yes
2. Are all variables set with logical defaults that are backward compatible?
   - Answer: yes
3. Can you provide a link to a Neptune experiment verifying the functionality of this PR?
   - Answer: [link](https://app.neptune.ai/o/pmtest/org/llm-random/runs/table?viewId=99f3d30d-6d52-4450-85bb-484c368e6e2b)
4. Have you successfully executed the linter and tests?
   - Answer: yes
5. Are all functions concise and don't require splitting?
   - Answer: yes
6. Is there documentation for arguments and complex logic?
   - Answer: yes
7. Are there no temporary solutions in the code? Should a task be added to Trello to refine the code?
   - Answer: chunking could be faster. Task added to trello.
8. Are all functions placed in appropriate files?
   - Answer: yes
9. Is the PR name meaningful and descriptive?
   - Answer: yes
10. Is PR description provided, or unnecessary?
    - Answer:  yes
  
Other questions:

11. Have you not made changes to the requirements or anything related to the Singularity image? If you have, did you generate and upload a new image to the clusters?
    - Answer: no such changes made
12. Is the change significant enough to notify all individuals working with this repository?
    - Answer: yup
13. Is there a need for a second reviewer?
    - Answer: yup
