### PR TITLE
allow_detaching_from_interactive_sessions

### DIFF
--- a/lizrd/scripts/run_exp_remotely.sh
+++ b/lizrd/scripts/run_exp_remotely.sh
@@ -22,7 +22,7 @@ run_grid_remotely() {
 
   script="cd $base_dir && tmux new-session -d -s $session_name bash"
   script+="; tmux send-keys -t $session_name 'python3 -m lizrd.scripts.grid $config' C-m"
-  script+="; tmux attach-session -t $session_name"
+  script+="; tmux attach -t $session_name"
   script+="; echo 'done'"
 
   ssh -t $host "$script"

--- a/lizrd/scripts/run_exp_remotely.sh
+++ b/lizrd/scripts/run_exp_remotely.sh
@@ -23,7 +23,7 @@ run_grid_remotely() {
   script="cd $base_dir && tmux new-session -d -s $session_name bash"
   script+="; tmux send-keys -t $session_name 'python3 -m lizrd.scripts.grid $config' C-m"
   script+="; tmux attach -t $session_name"
-  script+="; echo 'done'"
+  script+="; echo 'done'" #black magic: without it, interactive sessions like "srun" cannot be detached from without killing the session
 
   ssh -t $host "$script"
 }

--- a/lizrd/scripts/run_exp_remotely.sh
+++ b/lizrd/scripts/run_exp_remotely.sh
@@ -18,11 +18,12 @@ run_grid_remotely() {
   host=$1
   config=$2
   session_name=$(date "+%Y_%m_%d_%H_%M_%S")
-
+  echo "Running grid search on $host with config $config"
 
   script="cd $base_dir && tmux new-session -d -s $session_name bash"
   script+="; tmux send-keys -t $session_name 'python3 -m lizrd.scripts.grid $config' C-m"
-  script+="; tmux attach -t $session_name"
+  script+="; tmux attach-session -t $session_name"
+  script+="; echo 'done'"
 
   ssh -t $host "$script"
 }


### PR DESCRIPTION
# Description
script ended after tmux attach thus forcefully killing tmux session before one could properly detach, when using a srun interactive session.

# Checklist
Answer each question with "yes", and provide an explanation if the answer isn't what is expected.

1. Is this PR focused on a single feature without the possibility of being divided into smaller PRs?
   - Answer: yes
2. Are all variables set with logical defaults that are backward compatible?
   - Answer: yes 
3. Can you provide a link to a Neptune experiment verifying the functionality of this PR?
   - Answer: yes
4. Have you successfully executed the linter and tests?
   - Answer: yes
5. Are all functions concise and don't require splitting?
   - Answer: yes
6. Is there documentation for arguments and complex logic?
   - Answer: yes
7. Are there no temporary solutions in the code? Should a task be added to Trello to refine the code?
   - Answer: yes
8. Are all functions placed in appropriate files?
   - Answer: yes
9. Is the PR name meaningful and descriptive?
   - Answer: yes
10. Is PR description provided, or unnecessary?
    - Answer: yes
  
Other questions:

11. Have you not made changes to the requirements or anything related to the Singularity image? If you have, did you generate and upload a new image to the clusters?
    - Answer:
12. Is the change significant enough to notify all individuals working with this repository?
    - Answer:
13. Is there a need for a second reviewer?
    - Answer:
