### PR TITLE
Fixed positional embedding in blanx

### DIFF
--- a/research/blanks/argparse.py
+++ b/research/blanks/argparse.py
@@ -195,5 +195,6 @@ def introduce_parser_arguments(
     parser.add_argument("--blanks_learnable_weights", action="store_true")
     parser.add_argument("--blank_initial_weight", type=float, default=1.0)
     parser.add_argument("--blanks_use_straight_through", action="store_true")
+    parser.add_argument("--blanks_use_custom_positional_embedding", action="store_true")
 
     return parser

--- a/research/blanks/model.py
+++ b/research/blanks/model.py
@@ -37,7 +37,7 @@ def get_model(
     blanks_learnable_weights: bool = False,
     blank_initial_weight: float = 1.0,
     blanks_straight_through: bool = False,
-    use_blank_positional_embedding: bool = False,
+    blanks_use_custom_positional_embedding: bool = False,
 ):
     if model_fragmentation is None or device == torch.device("cpu"):
         first_gpu = device
@@ -46,7 +46,7 @@ def get_model(
         first_gpu = torch.device("cuda:0")
         last_gpu = torch.device(f"cuda:{len(model_fragmentation)}")
 
-    if use_blank_positional_embedding:
+    if blanks_use_custom_positional_embedding:
         positional_embedding = BlankPositionalEmbedding(
             max_length,
             dm,

--- a/research/blanks/model.py
+++ b/research/blanks/model.py
@@ -7,7 +7,6 @@ from research.blanks.utils import (
     shift_right,
     make_blanks_fixed_positions,
 )
-from typing import Literal
 from lizrd.core.initialization import get_init_weight
 
 
@@ -216,7 +215,7 @@ class BlankSeparateHead(torch.nn.Module):
         use_straight_through: bool = False,
     ):
         super().__init__()
-        self.linear = torch.nn.Linear(embedding_dim, output_size, bias=False)
+        self.linear = misc.Linear(embedding_dim, output_size, bias=False)
         self.blank_token_id = blank_token_id
         self.n_blanks = n_blanks
 

--- a/research/blanks/model.py
+++ b/research/blanks/model.py
@@ -52,6 +52,7 @@ def get_model(
             init_type=init_type,
             init_scale=init_scale,
             blank_token_id=blank_id,
+            n_blanks=n_blanks,
         ).to(first_gpu)
     else:
         positional_embedding = llm.PositionalEmbedding(
@@ -299,6 +300,7 @@ class BlankPositionalEmbedding(torch.nn.Module):
         init_type: Literal["kaiming_uniform", "truncated_normal"],
         init_scale: float,
         blank_token_id: int,
+        n_blanks: int,
     ):
         super(BlankPositionalEmbedding, self).__init__()
         self.layer = torch.nn.Embedding(max_length, embedding_dim)
@@ -311,8 +313,11 @@ class BlankPositionalEmbedding(torch.nn.Module):
             dtype=default_weight.dtype,
         )
         self.blank_token_id = blank_token_id
+        self.n_blanks = n_blanks
 
     def forward(self, x):
-        positions = make_blanks_fixed_positions(x, self.blank_token_id)
+        positions = make_blanks_fixed_positions(
+            x, self.blank_token_id, n_blanks_block=self.n_blanks
+        )
         embeddings = self.layer(positions)
         return embeddings

--- a/research/blanks/model.py
+++ b/research/blanks/model.py
@@ -37,6 +37,7 @@ def get_model(
     blanks_learnable_weights: bool = False,
     blank_initial_weight: float = 1.0,
     blanks_straight_through: bool = False,
+    use_blank_positional_embedding: bool = False,
 ):
     if model_fragmentation is None or device == torch.device("cpu"):
         first_gpu = device
@@ -45,15 +46,21 @@ def get_model(
         first_gpu = torch.device("cuda:0")
         last_gpu = torch.device(f"cuda:{len(model_fragmentation)}")
 
+    if use_blank_positional_embedding:
+        positional_embedding = BlankPositionalEmbedding(
+            max_length,
+            dm,
+            init_type=init_type,
+            init_scale=init_scale,
+            blank_token_id=blank_id,
+        ).to(first_gpu)
+    else:
+        positional_embedding = llm.PositionalEmbedding(
+            max_length, dm, init_type=init_type, init_scale=init_scale
+        ).to(first_gpu)
     if n_blanks > 0 and blanks_add_embedding:
         embedding_layer = llm.EmbeddingLayer(
-            BlankPositionalEmbedding(
-                max_length,
-                dm,
-                init_type=init_type,
-                init_scale=init_scale,
-                blank_token_id=blank_id,
-            ).to(first_gpu),
+            positional_embedding,
             BlankEmbedding(
                 vocab_size,
                 dm,
@@ -65,9 +72,7 @@ def get_model(
         )
     else:
         embedding_layer = llm.EmbeddingLayer(
-            llm.PositionalEmbedding(
-                max_length, dm, init_type=init_type, init_scale=init_scale
-            ).to(first_gpu),
+            positional_embedding,
             llm.TokenEmbedding(
                 vocab_size, dm, init_type=init_type, init_scale=init_scale
             ).to(first_gpu),

--- a/research/blanks/test_utils.py
+++ b/research/blanks/test_utils.py
@@ -108,7 +108,13 @@ class TestUtils(GeneralTestCase):
         )
 
     def test_make_blanks_fixed_positions(self):
-        tokens = torch.tensor([[0, 1, 0, 1], [0, 1, 1, 0], [1, 0, 1, 0]])
-        expected = torch.tensor([[0, 1, 1, 2], [0, 1, 2, 1], [0, 0, 1, 1]])
-        result = make_blanks_fixed_positions(tokens, 1)
+        tokens = torch.tensor([[0, 0, 1, 1, 0], [0, 1, 1, 0, 0], [1, 1, 0, 1, 1]])
+        expected = torch.tensor([[0, 1, 2, 3, 2], [0, 1, 2, 1, 2], [0, 1, 0, 1, 2]])
+        result = make_blanks_fixed_positions(tokens, 1, n_blanks_block=2)
         self.assertTrue(torch.equal(result, expected))
+
+    def test_make_blanks_fixed_positions_throws(self):
+        tokens = torch.tensor([[0, 0, 1, 1], [0, 1, 0, 0]])
+        self.assertRaises(
+            ValueError, make_blanks_fixed_positions, tokens, 1, n_blanks_block=2
+        )

--- a/research/blanks/test_utils.py
+++ b/research/blanks/test_utils.py
@@ -11,6 +11,7 @@ from research.blanks.utils import (
     shift_right,
     get_first_blanks_in_series,
     get_preblanks,
+    make_blanks_fixed_positions,
 )
 
 
@@ -105,3 +106,9 @@ class TestUtils(GeneralTestCase):
         self.assertFalse(
             can_fit_blanks(sequence_length, blank_insertion_point, n_blanks)
         )
+
+    def test_make_blanks_fixed_positions(self):
+        tokens = torch.tensor([[0, 1, 0, 1], [0, 1, 1, 0], [1, 0, 1, 0]])
+        expected = torch.tensor([[0, 1, 1, 2], [0, 1, 2, 1], [0, 0, 1, 1]])
+        result = make_blanks_fixed_positions(tokens, 1)
+        self.assertTrue(torch.equal(result, expected))

--- a/research/blanks/train.py
+++ b/research/blanks/train.py
@@ -117,6 +117,7 @@ def main(
         blanks_learnable_weights=args.blanks_learnable_weights,
         blank_initial_weight=args.blank_initial_weight,
         blanks_straight_through=args.blanks_use_straight_through,
+        blanks_use_custom_positional_embedding=args.blanks_use_custom_positional_embedding,
     )
 
     # make model data_distributed if necessary


### PR DESCRIPTION
# Description
Added new way of telling "which token is on what position", which includes blanks. Now, all tokens after blanks see their positions as if there were no blanks before them. The exception is blanks themself, which see all their position including all blanks in the same sequence.

Example (b is blank).
If the sequence is   aabaabba
Then positions are 01223454.

# Checklist
   - [x] Is this PR focused on a single feature without the possibility of being divided into smaller PRs?
   - [x] Are all variables set with logical defaults that are backward compatible?
   - [x] I attached link to neptune if it was necessary
   - [x] Have you successfully executed the linter and tests?
   - [x] Are all functions concise and don't require splitting?
   - [x] Is there documentation for arguments and complex logic?
   - [x] Are there no temporary solutions in the code? Should a task be added to Trello to refine the code?
   - [x] Are all functions placed in appropriate files?
   - [x] Is the PR name meaningful and descriptive?
   - [x] Is PR description provided, or unnecessary?
  
Other questions:
   - [x] If I made changes to the requirements or anything related to the Singularity image I did generate new image and upload a new image to the clusters
   - [x] If this change is significant enough I notified all individuals working with this repository (@channel in slack channel)
   - [x] If there is a need for a second reviewer I requested additional review 

# Reviewer's checklist:
   - [ ] Does the Neptune link work and does it actually compare the situation before and after the PR?
   - [ ] Do I understand the code?
   - [ ] Do I think another reviewer is not needed or I commented that this PR need another reviewer?
