### PR TITLE
Random seeding by default

### DIFF
--- a/research/blanks/train.py
+++ b/research/blanks/train.py
@@ -66,6 +66,8 @@ def main(
         args, extra = parser.parse_known_args(runner_params)
         if len(extra):
             print("Unknown args:", extra)
+        if args.data_seed < 0:
+            args.data_seed = random.randint(0, 10000000)
 
     if rank is not None:
         os.environ["MASTER_ADDR"] = "localhost"
@@ -230,6 +232,8 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     introduce_parser_arguments(parser)
     args = parser.parse_args()
+    if args.data_seed < 0:
+        args.data_seed = random.randint(0, 10000000)
 
     if args.data_distributed == False:
         main(None, args=args)

--- a/research/conditional/train/cc_train.py
+++ b/research/conditional/train/cc_train.py
@@ -82,6 +82,8 @@ def main(
         args, extra = parser.parse_known_args(runner_params)
         if len(extra):
             print("Unknown args:", extra)
+        if args.data_seed < 0:
+            args.data_seed = random.randint(0, 10000000)
 
     check_args(args)
     if args.save_weights_path is not None:
@@ -334,6 +336,8 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     introduce_parser_arguments(parser)
     args = parser.parse_args()
+    if args.data_seed < 0:
+        args.data_seed = random.randint(0, 10000000)
 
     if args.ddp_enabled or args.fsdp_enabled:
         random.seed(args.data_seed)

--- a/research/conditional/utils/argparse.py
+++ b/research/conditional/utils/argparse.py
@@ -123,7 +123,9 @@ def introduce_parser_arguments(
 
     parser.add_argument("--mask_loss_weight", type=float, default=1.0)
     parser.add_argument("--mask_percent", type=float, default=0.15)
-    parser.add_argument("--data_seed", type=int, default=42)
+    parser.add_argument(
+        "--data_seed", type=int, default=-1, help="Negative value means random seed"
+    )
     parser.add_argument("--torch_seed", type=int, default=42)
 
     # hardware


### PR DESCRIPTION
# Description
Set default behavior to random seed, but let users set seed.

Tested on local run with `num_workers=1`. default gave random examples, seed set to 42 yielded repeatable samples

# Checklist
   - [x] Is this PR focused on a single feature without the possibility of being divided into smaller PRs?
   - [x] Are all variables set with logical defaults that are backward compatible?
   - [x] I attached link to neptune if it was necessary
   - [x] Have you successfully executed the linter and tests?
   - [x] Are all functions concise and don't require splitting?
   - [x] Is there documentation for arguments and complex logic?
   - [x] Are there no temporary solutions in the code? Should a task be added to Trello to refine the code?
   - [x] Are all functions placed in appropriate files?
   - [x] Is the PR name meaningful and descriptive?
   - [x] Is PR description provided, or unnecessary?
  
Other questions:
   - [x] If I made changes to the requirements or anything related to the Singularity image I did generate new image and upload a new image to the clusters
   - [x] If this change is significant enough I notified all individuals working with this repository (@channel in slack channel)
   - [x] If there is a need for a second reviewer I requested additional review 

# Reviewer's checklist:
   - [ ] Does the Neptune link work and does it actually compare the situation before and after the PR?
   - [ ] Do I understand the code?
   - [ ] Do I think another reviewer is not needed or I commented that this PR need another reviewer?
