### PR TITLE
Get train and validation path from config

### DIFF
--- a/lizrd/grid/prepare_configs.py
+++ b/lizrd/grid/prepare_configs.py
@@ -89,8 +89,10 @@ def prepare_configs(
         # Here we should be confident that all the necessary keys are present in the config
         # Arguments below are used both in the runner and in the infrastructure
         config["params"]["n_gpus"] = config["n_gpus"]
-        config["params"]["train_dataset_path"] = config["train_dataset_path"]
-        config["params"]["validation_dataset_path"] = config["validation_dataset_path"]
+        config["params"].setdefault("train_dataset_path", config["train_dataset_path"])
+        config["params"].setdefault(
+            "validation_dataset_path", config["validation_dataset_path"]
+        )
 
     validate_configs(configs)
 


### PR DESCRIPTION
# Description
Previously we were overriding *_dataset_path, even if set in config.

# Checklist
   - [x] Is this PR focused on a single feature without the possibility of being divided into smaller PRs?
   - [x] Are all variables set with logical defaults that are backward compatible?
   - [x] I attached link to neptune if it was necessary
   - [x] Have you successfully executed the linter and tests?
   - [x] Are all functions concise and don't require splitting?
   - [x] Is there documentation for arguments and complex logic?
   - [x] Are there no temporary solutions in the code? Should a task be added to Trello to refine the code?
   - [x] Are all functions placed in appropriate files?
   - [x] Is the PR name meaningful and descriptive?
   - [x] Is PR description provided, or unnecessary?
  
Other questions:
   - [x] If I made changes to the requirements or anything related to the Singularity image I did generate new image and upload a new image to the clusters
   - [x] If this change is significant enough I notified all individuals working with this repository (@channel in slack channel)
   - [x] If there is a need for a second reviewer I requested additional review 

# Reviewer's checklist:
   - [ ] Does the Neptune link work and does it actually compare the situation before and after the PR?
   - [ ] Do I understand the code?
   - [ ] Do I think another reviewer is not needed or I commented that this PR need another reviewer?
