### PR TITLE
Add configurable initialization to KANLinear

### DIFF
--- a/configs/test/kan_profiler.yaml
+++ b/configs/test/kan_profiler.yaml
@@ -76,6 +76,9 @@ params:
   # init
   init_scale: 0.1
   init_type: truncated_normal
+  init_scale_base: 0.1
+  init_scale_spline: 0.1
+  init_scale_noise: 0.01
 
   # debug
   # logger_types: "stdout"

--- a/configs/test/kan_vanilla.yaml
+++ b/configs/test/kan_vanilla.yaml
@@ -49,7 +49,7 @@ params:
 
   # # mini size
   dmodel: 256
-  ^dff: [92]
+  dff: 1024
   n_blocks: 4
   n_att_heads: 4
 
@@ -59,7 +59,7 @@ params:
   logging_interval_heavy: 200
   logging_interval_loss: 50
 
-  ^ff_mode: [kan_square_latent]
+  ^ff_mode: [kan]
   use_torch_bmm: true
   softmax_over: experts
 
@@ -69,6 +69,12 @@ params:
   init_scale_base: 0.1
   init_scale_spline: 0.1
   init_scale_noise: 0.01
+
+  init_scale: 69
+  init_type: truncated_normal
+  init_scale_base: 69
+  init_scale_spline: 69
+  init_scale_noise: 69
 
   # profiler
   # profiler_enabled: true
@@ -80,12 +86,12 @@ params:
   # profiler_schedule_skip_first: 20
 
   # debug
-  # logger_types: "stdout"
-  # use_dummy_dataset: true
-  # n_blocks: 1
-  # n_att_heads: 1
-  # zloss_weight: 0
+  logger_types: "stdout"
+  use_dummy_dataset: true
+  n_blocks: 1
+  n_att_heads: 1
+  zloss_weight: 0
 
-  # dmodel: 16
-  # n_blocks: 1
-  # n_att_heads: 2
+  dmodel: 16
+  n_blocks: 1
+  n_att_heads: 2

--- a/configs/test/kan_vanilla.yaml
+++ b/configs/test/kan_vanilla.yaml
@@ -66,6 +66,9 @@ params:
   # init
   init_scale: 0.1
   init_type: truncated_normal
+  init_scale_base: 0.1
+  init_scale_spline: 0.1
+  init_scale_noise: 0.01
 
   # profiler
   # profiler_enabled: true

--- a/configs/test/kanmoe_config.yaml
+++ b/configs/test/kanmoe_config.yaml
@@ -64,6 +64,9 @@ params:
   # init
   init_scale: 0.1
   init_type: truncated_normal
+  init_scale_base: 0.1
+  init_scale_spline: 0.1
+  init_scale_noise: 0.01
 
   # debug
   # logger_types: "stdout"

--- a/research/conditional/moe_layers/expert_types.py
+++ b/research/conditional/moe_layers/expert_types.py
@@ -1,12 +1,13 @@
 from typing import Optional
 
 import torch
+import math
 from fancy_einsum import einsum
 
 from lizrd.core.initialization import get_init_fun
 from lizrd.core.misc import resolve_activation_name
 from lizrd.core.misc import LoggingLayer, time_measured
-from lizrd.core.kan import KanFF, Kan_sQare
+from lizrd.core.kan import KanFF, Kan_sQare, MlpKan_norelu, KanSquareLatent
 
 
 class ExpertKAN(LoggingLayer):
@@ -40,6 +41,46 @@ class ExpertKAN(LoggingLayer):
                 [KanFF(dmodel=dmodel, dff=expert_size) for _ in range(n_experts)]
             )
 
+
+class ExpertMLPKAN(LoggingLayer):
+    def __init__(
+        self,
+        dmodel: int,
+        n_experts: int,
+        expert_size: int,
+        init_type: str,
+        init_scale: float,
+        use_topk_initialization,
+        activation_name: str = "relu",
+        topk: int = 1,
+        kan_square=False,
+    ):
+        super().__init__()
+        self.dmodel = dmodel
+        self.n_experts = n_experts
+        self.expert_size = expert_size
+        self.activation = resolve_activation_name(activation_name)
+        self.doutput = dmodel
+
+        kan_bottleneck_size = self.calculate_kan_bottlneck(kan_square)
+
+        print(f"\nexpert_size = dff = {expert_size}\n")
+
+        if kan_square:
+            self.kan_experts = torch.nn.ModuleList(
+                [
+                    KanSquareLatent(dmodel=dmodel, dff=kan_bottleneck_size)
+                    for _ in range(n_experts)
+                ]
+            )
+        else:
+            self.kan_experts = torch.nn.ModuleList(
+                [
+                    MlpKan_norelu(dmodel=dmodel, dff=kan_bottleneck_size)
+                    for _ in range(n_experts)
+                ]
+            )
+
     @time_measured("process_by_experts")
     def forward(self, x: torch.Tensor):
         n_experts, capacity, dmodel = x.shape
@@ -56,6 +97,22 @@ class ExpertKAN(LoggingLayer):
         assert output.shape == x.shape
 
         return output
+
+    def calculate_kan_bottlneck(self, kan_square):
+        kan_bottlneck = None
+
+        if kan_square:
+            kan_bottlneck = int(
+                (
+                    math.sqrt(self.dmodel * (20 * self.expert_size + self.dmodel))
+                    - self.dmodel
+                )
+                / 10
+            )
+        else:
+            kan_bottlneck = int((2 / 11) * self.expert_size)
+
+        return kan_bottlneck
 
 
 class ExpertFF(LoggingLayer):

--- a/research/conditional/utils/argparse.py
+++ b/research/conditional/utils/argparse.py
@@ -39,9 +39,16 @@ def introduce_parser_arguments(
         required=True,
     )
     parser.add_argument("--init_scale", type=float, required=True)
-    parser.add_argument("--init_scale_base", type=float, required=False)
-    parser.add_argument("--init_scale_spline", type=float, required=False)
-    parser.add_argument("--init_scale_noise", type=float, required=False)
+    parser.add_argument("--init_scale_base", type=float, default=0.1, required=False)
+    parser.add_argument("--init_scale_spline", type=float, default=0.1, required=False)
+    parser.add_argument("--init_scale_noise", type=float, default=0.1, required=False)
+    parser.add_argument(
+        "--kan_latent_factor",
+        type=float,
+        default=1.0,
+        required=False,
+        help="in kan_latent specity how many times kan should increase dimensionality",
+    )
 
     # other training hyperparameters
 

--- a/research/conditional/utils/argparse.py
+++ b/research/conditional/utils/argparse.py
@@ -39,6 +39,9 @@ def introduce_parser_arguments(
         required=True,
     )
     parser.add_argument("--init_scale", type=float, required=True)
+    parser.add_argument("--init_scale_base", type=float, required=False)
+    parser.add_argument("--init_scale_spline", type=float, required=False)
+    parser.add_argument("--init_scale_noise", type=float, required=False)
 
     # other training hyperparameters
 

--- a/research/conditional/utils/model_utils.py
+++ b/research/conditional/utils/model_utils.py
@@ -77,6 +77,7 @@ from research.conditional.moe_layers.expert_types import (
     ExpertFF,
     ExpertGated,
     ExpertKAN,
+    ExpertMLPKAN,
     ExpertLinear,
 )
 from research.mamba.moe_in_mamba import MambaInProj
@@ -778,6 +779,12 @@ def get_inner_expert(args):
         expert_inner_class = partial(ExpertKAN, activation_name="relu")
     elif args.moe_inner_expert == "kan_squared":
         expert_inner_class = partial(ExpertKAN, activation_name="relu", kan_square=True)
+    elif args.moe_inner_expert == "mlp_kan":
+        expert_inner_class = partial(ExpertMLPKAN, activation_name="relu")
+    elif args.moe_inner_expert == "kan_square_latent":
+        expert_inner_class = partial(
+            ExpertMLPKAN, activation_name="relu", kan_square=True
+        )
     else:
         raise NotImplementedError(
             f'Inner expert type "{args.moe_inner_expert}" not implemented'

--- a/research/conditional/utils/model_utils.py
+++ b/research/conditional/utils/model_utils.py
@@ -546,31 +546,71 @@ def get_ff_layer(args):
         return_fn = lambda: kan.Identity()
     elif args.ff_mode == "kan":
         return_fn = lambda: kan.KanFF(
-            args.dmodel, args.dff, init_type=args.init_type, init_scale=args.init_scale
+            args.dmodel,
+            args.dff,
+            init_type=args.init_type,
+            init_scale_base=args.init_scale_base,
+            init_scale_spline=args.init_scale_spline,
+            init_scale_noise=args.init_scale_noise,
         )
     elif args.ff_mode == "kan_squared":
         return_fn = lambda: kan.Kan_sQare(
-            args.dmodel, args.dff, init_type=args.init_type, init_scale=args.init_scale
+            args.dmodel,
+            args.dff,
+            init_type=args.init_type,
+            init_scale_base=args.init_scale_base,
+            init_scale_spline=args.init_scale_spline,
+            init_scale_noise=args.init_scale_noise,
         )
     elif args.ff_mode == "mlp_kan":
         return_fn = lambda: kan.MlpKan(
-            args.dmodel, args.dff, init_type=args.init_type, init_scale=args.init_scale
+            args.dmodel,
+            args.dff,
+            init_type=args.init_type,
+            init_scale=args.init_scale,
+            init_scale_base=args.init_scale_base,
+            init_scale_spline=args.init_scale_spline,
+            init_scale_noise=args.init_scale_noise,
         )
     elif args.ff_mode == "mlp_kan_norelu":
         return_fn = lambda: kan.MlpKan_norelu(
-            args.dmodel, args.dff, init_type=args.init_type, init_scale=args.init_scale
+            args.dmodel,
+            args.dff,
+            init_type=args.init_type,
+            init_scale=args.init_scale,
+            init_scale_base=args.init_scale_base,
+            init_scale_spline=args.init_scale_spline,
+            init_scale_noise=args.init_scale_noise,
         )
     elif args.ff_mode == "kan_latent":
         return_fn = lambda: kan.KanLatent(
-            args.dmodel, args.dff, init_type=args.init_type, init_scale=args.init_scale
+            args.dmodel,
+            args.dff,
+            init_type=args.init_type,
+            init_scale=args.init_scale,
+            init_scale_base=args.init_scale_base,
+            init_scale_spline=args.init_scale_spline,
+            init_scale_noise=args.init_scale_noise,
         )
     elif args.ff_mode == "kan_square_latent":
         return_fn = lambda: kan.KanSquareLatent(
-            args.dmodel, args.dff, init_type=args.init_type, init_scale=args.init_scale
+            args.dmodel,
+            args.dff,
+            init_type=args.init_type,
+            init_scale=args.init_scale,
+            init_scale_base=args.init_scale_base,
+            init_scale_spline=args.init_scale_spline,
+            init_scale_noise=args.init_scale_noise,
         )
     elif args.ff_mode == "kan_mlp":
         return_fn = lambda: kan.KanMlp(
-            args.dmodel, args.dff, init_type=args.init_type, init_scale=args.init_scale
+            args.dmodel,
+            args.dff,
+            init_type=args.init_type,
+            init_scale=args.init_scale,
+            init_scale_base=args.init_scale_base,
+            init_scale_spline=args.init_scale_spline,
+            init_scale_noise=args.init_scale_noise,
         )
     elif args.ff_mode == "swi_glu":
         return_fn = lambda: llm.SwiGLUFeedForward(


### PR DESCRIPTION
# Description
Add 3 parameters determining initialization of KAN.
init_scale_base: 0.1
init_scale_spline: 0.1
init_scale_noise: 0.01 

# Checklist
   - [ ] Is this PR focused on a single feature without the possibility of being divided into smaller PRs?
   - [ ] Are all variables set with logical defaults that are backward compatible?
   - [ ] I attached link to neptune if it was necessary
   - [ ] Have you successfully executed the linter and tests?
   - [ ] Are all functions concise and don't require splitting?
   - [ ] Is there documentation for arguments and complex logic?
   - [ ] Are there no temporary solutions in the code? Should a task be added to Trello to refine the code?
   - [ ] Are all functions placed in appropriate files?
   - [ ] Is the PR name meaningful and descriptive?
   - [ ] Is PR description provided, or unnecessary?
  
Other questions:
   - [ ] If I made changes to the requirements or anything related to the Singularity image I did generate new image and upload a new image to the clusters
   - [ ] If this change is significant enough I notified all individuals working with this repository (@channel in slack channel)
   - [ ] If there is a need for a second reviewer I requested additional review 

# Reviewer's checklist:
   - [ ] Does the Neptune link work and does it actually compare the situation before and after the PR?
   - [ ] Do I understand the code?
   - [ ] Do I think another reviewer is not needed or I commented that this PR need another reviewer?
