### PR TITLE
Fix active param count

### DIFF
--- a/lizrd/support/logging.py
+++ b/lizrd/support/logging.py
@@ -500,22 +500,21 @@ class JointLogger(AbstractLogger):
 
 def log_and_print_model_param_count(args, model):
     n_learnable_parameters = get_n_learnable_parameters(model)
-    args.n_learnable_parameters = n_learnable_parameters
-    print(f"Number of learnable parameters: {n_learnable_parameters:_}")
+    args.model_n_params_with_embedding = n_learnable_parameters
 
     n_learnable_nonembedding_parameters = get_total_nonembedding_parameters(model)
-    args.n_learnable_nonembedding_parameters = n_learnable_nonembedding_parameters
-    print(
-        f"Number of learnable nonembedding parameters: {n_learnable_nonembedding_parameters:_}"
-    )
+    args.model_n_params = n_learnable_nonembedding_parameters
 
     n_active_learnable_nonembedding_parameters = get_active_nonembedding_parameters(
         args, model
     )
     args.model_n_active = n_active_learnable_nonembedding_parameters
-    print(
-        f"Number of active nonembedding parameters: {n_active_learnable_nonembedding_parameters:_}"
+
+    embedding_params = n_learnable_parameters - n_learnable_nonembedding_parameters
+    args.model_n_active_with_embedding = (
+        n_active_learnable_nonembedding_parameters + embedding_params
     )
+    args.model_embedding_params = embedding_params
 
     tokens_per_step = count_tokens_per_step(args.batch_size, args.cutoff)
     args.tokens_per_step = tokens_per_step
@@ -525,7 +524,13 @@ def log_and_print_model_param_count(args, model):
         n_active=n_active_learnable_nonembedding_parameters,
         args=args,
     )
-    args.final_tokens_per_act_param = token_to_active_ratio
+    args.token_to_active_ratio = token_to_active_ratio
+
+    print(f"Model total parameters: {n_learnable_parameters:_}")
+    print(f"Model nonembedding parameters: {n_learnable_nonembedding_parameters:_}")
+    print(
+        f"Model active nonembedding parameters: {n_active_learnable_nonembedding_parameters:_}"
+    )
     print(f"#tokens / #active: {token_to_active_ratio:.2f}")
 
 

--- a/lizrd/support/logging.py
+++ b/lizrd/support/logging.py
@@ -175,11 +175,11 @@ class AbstractLogger(ABC):
 
         return auxiliary_metrics
 
-    def start_job_metadata(self, trining_step: int):
+    def start_job_metadata(self, training_step: int):
         self.report_text(
             title=f"job/{self.TITLE_JOB_STATE}",
             value=self.STATE_JOB_RUNNING,
-            iteration=trining_step,
+            iteration=training_step,
         )
 
         text_logs = {}
@@ -196,14 +196,14 @@ class AbstractLogger(ABC):
 
         for to_log in text_logs.items():
             self.report_text(
-                title=f"job/{to_log[0]}", value=to_log[1], iteration=trining_step
+                title=f"job/{to_log[0]}", value=to_log[1], iteration=training_step
             )
 
-    def exit_job_metadata(self, trining_step: int):
+    def exit_job_metadata(self, training_step: int):
         self.report_text(
             title=f"job/{self.TITLE_JOB_STATE}",
             value=self.STATE_JOB_FINISHED,
-            iteration=trining_step,
+            iteration=training_step,
         )
 
 

--- a/research/conditional/train/cc_train.py
+++ b/research/conditional/train/cc_train.py
@@ -10,11 +10,14 @@ import torch.multiprocessing as mp
 from torch.distributed import init_process_group, destroy_process_group
 
 from lizrd.core import misc
-from lizrd.core.llm import EmbeddingLayer, Parallel
-from lizrd.support.logging import get_current_logger, get_logger
+from lizrd.core.llm import Parallel
+from lizrd.support.logging import (
+    get_current_logger,
+    get_logger,
+    log_and_print_model_param_count,
+)
 from lizrd.support.misc import (
     get_argument_attributes,
-    get_n_learnable_parameters,
     set_seed,
 )
 from lizrd.train.train_utils import (
@@ -256,22 +259,7 @@ def main(
         checkpoint=checkpoint,
     )
 
-    n_learnable_parameters = get_n_learnable_parameters(model)
-    args.n_learnable_parameters = n_learnable_parameters
-    print(f"Number of learnable parameters: {n_learnable_parameters:_}")
-
-    embedding = [m for m in model.modules() if isinstance(m, EmbeddingLayer)][0]
-    head = model.head
-
-    n_learnable_nonembedding_parameters = (
-        n_learnable_parameters
-        - get_n_learnable_parameters(embedding)
-        - get_n_learnable_parameters(head)
-    )
-    args.n_learnable_nonembedding_parameters = n_learnable_nonembedding_parameters
-    print(
-        f"Number of learnable nonembedding parameters: {n_learnable_nonembedding_parameters:_}"
-    )
+    log_and_print_model_param_count(args, model)
 
     if args.torch_compile:
         model = torch.compile(model)

--- a/research/conditional/utils/conditional_trainer.py
+++ b/research/conditional/utils/conditional_trainer.py
@@ -110,7 +110,8 @@ class ConditionalTrainer:
         self._check_config()
 
     def _before_train_operations(self):
-        self.logger.start_job_metadata(self.start_step)
+        if self.is_logging_process:
+            self.logger.start_job_metadata(self.start_step)
         propagate_forward_pass_cache(self.model)
         update_model_fit_gpu_info(
             self.model_fit_gpu_info_database_path,
@@ -124,7 +125,8 @@ class ConditionalTrainer:
             self.model_fit_gpu_info_params,
             "success",
         )
-        self.logger.exit_job_metadata(self.current_step)
+        if self.is_logging_process:
+            self.logger.exit_job_metadata(self.current_step)
 
     def _after_step_operations(self, step):
         self.model.forward_pass_cache.clear()

--- a/research/conditional/utils/conditional_trainer.py
+++ b/research/conditional/utils/conditional_trainer.py
@@ -286,7 +286,9 @@ class ConditionalTrainer:
                 self.eval_min_group_size_logfactor,
                 self.eval_max_group_size_logfactor + 1,
             ):
-                current_group_size = int(2**log_group_size_factor * original_group_size)
+                current_group_size = int(
+                    2**log_group_size_factor * original_group_size
+                )
                 if (
                     current_group_size
                     <= self.batch_size // self.gradient_accumulation_steps


### PR DESCRIPTION
# Description
Calulates active params for token_choice and expert_choice. for all other options the assumption is: active == total.
There is also a name change in args. these args are there for logging purposes, and I think that their names were confusing.
Last thing: printing of parameter count, active count and token to active ratio has been abstracted from cc_train to a function in logger.py

# Checklist
   - [x] Is this PR focused on a single feature without the possibility of being divided into smaller PRs?
   - [x] Are all variables set with logical defaults that are backward compatible?
   - [x] [I attached link to neptune if it was necessary](https://app.neptune.ai/o/pmtest/org/llm-random/runs/compare?viewId=9d441a96-cc77-408b-85c9-6e9acabe5a0b&dash=dashboard&dashboardId=-loss-interval-1-step-9aaea80a-268f-4f2e-b13f-799ef22747e6&compare=IwDg7MCcA0xA)
   - [x] Have you successfully executed the linter and tests?
   - [x] Are all functions concise and don't require splitting?
   - [x] Is there documentation for arguments and complex logic?
   - [x] Are there no temporary solutions in the code? Should a task be added to Trello to refine the code?
   - [x] Are all functions placed in appropriate files?
   - [x] Is the PR name meaningful and descriptive?
   - [x] Is PR description provided, or unnecessary?
  
Other questions:
   - [ ] If I made changes to the requirements or anything related to the Singularity image I did generate new image and upload a new image to the clusters
   - [ ] If this change is significant enough I notified all individuals working with this repository (@channel in slack channel)
   - [ ] If there is a need for a second reviewer I requested additional review 

# Reviewer's checklist:
   - [ ] Does the Neptune link work and does it actually compare the situation before and after the PR?
   - [ ] Do I understand the code?
   - [ ] Do I think another reviewer is not needed or I commented that this PR need another reviewer?
