### PR TITLE
Fix bug - no checkpoint manager but save path error

### DIFF
--- a/research/conditional/train/cc_train.py
+++ b/research/conditional/train/cc_train.py
@@ -600,6 +600,7 @@ def main(
         get_final_eval_dataloader=get_final_eval_dataloader,
         final_eval_dataloader_batch_size=args.final_eval_dataloader_batch_size,
         n_final_eval_batches=args.n_final_eval_batches,
+        checkpoint_manager=args.checkpoint_manager,
     )
     trainer.train(args.n_steps)
 

--- a/research/conditional/utils/conditional_trainer.py
+++ b/research/conditional/utils/conditional_trainer.py
@@ -153,7 +153,7 @@ class ConditionalTrainer:
             self.logger.exit_job_metadata(self.current_step)
 
         if self.current_step >= n_steps:  # - end of model training operations
-            if self.save_weights_path:
+            if self.save_weights_path and self.checkpoint_manager:
                 job_id = get_slurm_job_id()
                 end_training_checkpoint(
                     job_id,


### PR DESCRIPTION
# Description
Case when checkpoint manager system is prompted when not used, when save_weights_path provided

# Checklist
   - [ ] Is this PR focused on a single feature without the possibility of being divided into smaller PRs?
   - [ ] Are all variables set with logical defaults that are backward compatible?
   - [ ] I attached link to neptune if it was necessary
   - [ ] Have you successfully executed the linter and tests?
   - [ ] Are all functions concise and don't require splitting?
   - [ ] Is there documentation for arguments and complex logic?
   - [ ] Are there no temporary solutions in the code? Should a task be added to Trello to refine the code?
   - [ ] Are all functions placed in appropriate files?
   - [ ] Is the PR name meaningful and descriptive?
   - [ ] Is PR description provided, or unnecessary?
  
Other questions:
   - [ ] If I made changes to the requirements or anything related to the Singularity image I did generate new image and upload a new image to the clusters
   - [ ] If this change is significant enough I notified all individuals working with this repository (@channel in slack channel)
   - [ ] If there is a need for a second reviewer I requested additional review 

# Reviewer's checklist:
   - [ ] Does the Neptune link work and does it actually compare the situation before and after the PR?
   - [ ] Do I understand the code?
   - [ ] Do I think another reviewer is not needed or I commented that this PR need another reviewer?
